### PR TITLE
Fix GetFileContent API call failure

### DIFF
--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -320,7 +320,8 @@ class Client
     public function GetFileContent($shareId, $uploadName, $domain, $token)
     {
         try {
-            $response = $this->client->get($this->FileURL($domain, $shareId, $uploadName), $this->AuthHeaders($token));
+            $request = new Request('GET', $this->FileURL($domain, $shareId, $uploadName), $this->AuthHeaders($token));
+            $response = $this->client->send($request);
         } catch (ClientException $exception) {
             $this->throwException($exception->getResponse(), "Could not download file.");
         }


### PR DESCRIPTION
This fixes the issue when an API caller uses `GetFileContent` directly ore indirectly, it returns authentication failure.