### PR TITLE
Allow API client class to receive Guzzle config

### DIFF
--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -68,11 +68,11 @@ class Client
         'Content-Type' => 'application/json',
     ];
 
-    public function __construct()
+    public function __construct(array $config = [])
     {
         $this->deviceOS = php_uname('s') . ' ' . php_uname('');
 
-        $this->client = new HttpClient();
+        $this->client = new HttpClient($config);
     }
 
     /**


### PR DESCRIPTION
API Client class is basically Guzzle Client's wrapper but it doesn't
have a hook to pass default configuration to the Guzzle Client.

This adds an argument to API Client constructor which allows to pass
Guzzle Client configuration to Guzzle Client.

This is useful to avoid curl's unrecognized content encoding type error
by passing decode_content false configuration to the client.

It may be better to have methods to pass client configuration after creating an instance.